### PR TITLE
Limit build and publish runs to 15 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on: pull_request
 jobs:
   gradle:
     runs-on: "ubuntu-latest"
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-java@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ jobs:
   generate:
     name: Create release-artifacts
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout the repository
         uses: actions/checkout@master


### PR DESCRIPTION
No more forever-builds billing against your minutes because of infrastructure hiccups like this.

All initial reads suggest builds here typically take 5-8 minutes so 15 should cover minor blips and not leave us with excessive flakes.