### PR TITLE
Filter JEI repository definitions 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,10 +129,16 @@ repositories {
     maven { // JEI
         name 'DVS1 Maven FS'
         url 'https://dvs1.progwml6.com/files/maven'
+        content  {
+            includeGroup "mezz.jei"
+        }
     }
     maven { // location of a maven mirror for JEI files, as a fallback
-        name = "ModMaven"
-        url = "https://modmaven.dev"
+        name "ModMaven"
+        url "https://modmaven.dev"
+        content  {
+            includeGroup "mezz.jei"
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,11 @@
 buildscript {
     repositories {
-        maven { url = 'https://maven.minecraftforge.net' }
+        maven { 
+          url 'https://maven.minecraftforge.net'
+	  content {
+             includeGroupByRegex "net.minecraftforge.*"
+          }
+	}
         maven { url = 'https://plugins.gradle.org/m2/' }
         mavenCentral()
     }


### PR DESCRIPTION
This is aggressive performance tuning - Every additional repository creates additional HTTP requests. In an ideal build, every GAV should be whitelisted to the repository you intend, but at minimum, we should have all the lower-volume CDNs whitelisted so we aren't abused as heavily.