### PR TITLE
Add affinity lint and affinity datapack autogeneration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,16 @@
     <a title="Discord" target="_blank" href="https://discord.gg/VYqn7wGKaS"><img alt="Discord" src="https://img.shields.io/discord/880654627270434896?logo=discord&logoColor=ffffff&label=Discord&color=5865f2"></a>
 </h2>
 <p>Primal Magick is a magick-themed mod for Minecraft.  Research new items, cast spells, and attune yourself to the wonders of magick!  To get started, simply go exploring and check out any ancient shrines you happen to find along the way.  Everything else you need to progress is taught to you in the course of play, no external wikis needed!</p>
+
+
+## For Mod/Modpack Maintainers
+
+### Adding affinities for other mods
+
+PrimalMagick derives affinities for items from their recipes; for base items that have no recipe, you will need to provide datapack-format affinity definitions.
+
+The below commands will make generating these affinities correctly easier when run inside a minecraft instance with PrimalMagic and your mod(s).
+
+/pm affinities lint [all] - iterates over all items to identify which have no sources and logs a list of items that resolve to empty sourceLists in ResourceLocation (mod:itemname) form. Also sends a message to the triggering player with a count of items missing sources. By default, will skip over any entities in minecraft and primalmagick namespaces, on the theory that the mod owner owns the task of maintaining those.
+
+/pm affinities generateDatapack [all] - Performs the same task as above, including skipping minecraft and primalmagick namespaces by default, then writes a datapack to disk in the configured java temp directory containing all the affected items. The path to the file is written to system logs.

--- a/src/main/java/com/verdantartifice/primalmagick/common/util/DataPackUtils.java
+++ b/src/main/java/com/verdantartifice/primalmagick/common/util/DataPackUtils.java
@@ -1,0 +1,101 @@
+package com.verdantartifice.primalmagick.common.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.minecraftforge.registries.ForgeRegistries;
+
+public class DataPackUtils {
+    
+    /*
+     * All right. 
+     * 
+     * Inputs:
+     *  List of items
+     * 
+     * Outputs:
+     *  Zip file in datapack format containing:
+     *   - a pack.mcmeta file including FML extensions for the mod
+     *   - subdirectory data/primalmagick/affinities/item
+     *   - one file per item named with the itemname containing fields:
+     *     - { "type": "item", "set": { "earth": 0, "sun": 0, "moon": 0, "sky": 0, "sea": 0 }, "target": resourceName}
+     *       - there's no schema-first model here; there's a deserializer but not a serializer for the datapack format.
+     */
+
+    static String itemFilePrefix = "data/primalmagick/affinities/item/";
+
+    static String packMCMetaFilename = "pack.mcmeta";
+    static String packMCMeta = """
+        {
+            "pack": {
+              "description": "Primal Magick ModPack Base Item Affinities",
+              "pack_format": 15
+            }
+        }
+    """;
+
+    // I'm also assuming that explicitly setting 0 for things is free, so if people use these templates without cleaning them up
+    // noone'll care.
+    // I'm also also assuming that if you're writing a modpack you don't care about spoilers. 
+    // SPOILERS:
+    static String itemTemplate = """
+            { "type": "item", 
+              "set": { 
+                "earth": 0, 
+                "sun": 0, 
+                "moon": 0, 
+                "sky": 0, 
+                "sea": 0, 
+                "blood": 0, 
+                "infernal": 0, 
+                "void": 0, 
+                "hallowed": 0 
+              }, 
+              "target": "%s"
+            }
+        """;
+        // /SPOILERS. nyah.
+
+    public static byte[] ItemsToDataPackTemplate(List<Item> sourceItems) throws IOException{
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ZipOutputStream zos = new ZipOutputStream(bos);
+
+        ZipEntry z = new ZipEntry(packMCMetaFilename);
+        zos.putNextEntry(z);
+        zos.write(packMCMeta.getBytes());
+        zos.closeEntry();
+
+
+        for (Item item : sourceItems) {
+            @Nullable
+            ResourceLocation resourceLocation = ForgeRegistries.ITEMS.getKey(item);
+            if (resourceLocation != null) {
+                String target = resourceLocation.toString();
+                String filename = target.replace(":", "_")+".json";
+
+                z = new ZipEntry(itemFilePrefix + filename);
+                zos.putNextEntry(z);
+                zos.write(String.format(itemTemplate, target).getBytes());
+                zos.closeEntry();
+            }
+        }
+
+        zos.close();
+
+        return bos.toByteArray();
+     }
+
+
+
+
+
+
+}

--- a/src/main/java/com/verdantartifice/primalmagick/common/util/DataPackUtils.java
+++ b/src/main/java/com/verdantartifice/primalmagick/common/util/DataPackUtils.java
@@ -29,7 +29,7 @@ public class DataPackUtils {
      *       - there's no schema-first model here; there's a deserializer but not a serializer for the datapack format.
      */
 
-    static String itemFilePrefix = "data/primalmagick/affinities/item/";
+    static String itemFilePrefix = "data/primalmagick/affinities/items/";
 
     static String packMCMetaFilename = "pack.mcmeta";
     static String packMCMeta = """


### PR DESCRIPTION
## Why?
As I set about building a modpack, I found the process of identifying which items from other mods needed explicit sources set in order to engage with Primal Magick affinities.

From poking at the mod, I believe the correct qualifier for needing manual assistance is items:
 - with no affinities
 - and with no recipes they could be derived from.

I also found developing a datapack with the proper structure unintuitive and as of this writing either poorly documented or exceedingl well hidden; automatically generating a datapack framework would also make the work much easier.

## Changes

This PR adds a new set of commands to the `/primalmagick` command set, intended for modpack maintainers and system owners to use. These commands output to system logs and temp directories, so if you're not the admin of the server, they're not going to do you much good.

`/pm affinities lint [all]` - iterates over all items to identify which have no sources and logs a list of items that resolve to empty sourceLists in ResourceLocation (mod:itemname) form. Also sends a message to the triggering player with a count of items missing sources. By default, will skip over any entities in `minecraft` and `primalmagick` namespaces, on the theory that the mod owner owns the task of maintaining those.

`/pm affinities generateDatapack [all]` - Performs the same task as above, including skipping `minecraft` and `primalmagick` namespaces by default, then writes a datapack to disk in the configured java temp directory containing all the affected items. The path to the file is written to system logs.

## Usage

As you develop your modpack and add mods, use the `/pm affinities generateDatapack` to build an initial set of missing items. Unpack the resulting datapack into a _subdirectory_ of your `datapacks/` directory and edit the individual json files to set sources. Include the datapack in your modpack to ensure PrimalMagic produces affinities for all items.

Datapacks are re-rendered live whenever the world loads or `/reload` is invoked; add affinities and run `/pm affinities lint` until you're satisfied with the remaining count.

## Limitations

At this writing there's no differentiation at the API layer for items that explicitly have no sources versus items that have no definition yet. If your goal is getting lint to tell you that there are 0 missing items, you'll need to set sources for Creative-only items and other oddities, regardless of their irrelevance to live gameplay.  