### PR TITLE
Add Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,54 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug", "triage"]
+assignees:
+  - daedalus4096
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: What went wrong?
+    validations:
+      required: true
+  - type: textarea
+    id: what-should-have-happened
+    attributes:
+      label: What did you expect to happen?
+      description: What was the _correct_ behavior that didn't happen?
+      placeholder: What should have happened?
+    validations:
+      required: true
+  - type: textarea
+    id: how-to-reproduce
+    attributes:
+      label: How can we reproduce this bug?
+      description: Step-by-step how-to
+      placeholder: Magic is a complicated entity.
+    validations:
+      required: true
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you running?
+      options:
+        - 4.1.x (MC 1.20.2) (Current)
+        - 4.0.x (MC 1.20.1)
+        - 3.x (1.19.2)
+        - 2.x (1.18.2)
+      default: 0
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+---
+blank_issues_enabled: true


### PR DESCRIPTION
Unfortunately, no way to iterate on this without commits on main or testing on a different repo, which might be the sane thing.

https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository

Figure it's a good idea to make it a form, save explaining to noobs how to write a good bug report :-)

