### PR TITLE
add git-version plugin to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 plugins {
     // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
     id 'net.neoforged.moddev' version '0.1.110' apply false
+    id 'com.palantir.git-version' version '3.1.0'
 }


### PR DESCRIPTION
Quick fix - looks like the new frame moved most everything out of the build.gradle; readding the plugin there. There's also a plugins block in settings.gradle; I'm not sure why to change one vs the other, but this cleared the error.