### PR TITLE
Specify version property in allProjects in root project.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-java@v1
       with:
-        java-version: 8
+        java-version: 21
     - uses: actions/cache@v1
       with:
         path: ~/.gradle/caches

--- a/build.gradle
+++ b/build.gradle
@@ -3,3 +3,7 @@ plugins {
     id 'net.neoforged.moddev' version '0.1.110' apply false
     id 'com.palantir.git-version' version '3.1.0'
 }
+
+allprojects {
+    version = gitVersion()
+}

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -3,8 +3,6 @@ plugins {
     id 'net.neoforged.moddev'
 }
 
-version = gitVersion()
-
 neoForge {
     neoFormVersion = neo_form_version
     // Automatically enable AccessTransformers if the file exists

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -4,8 +4,6 @@ plugins {
     id 'org.spongepowered.mixin' version '0.7-SNAPSHOT'
 }
 
-version = gitVersion()
-
 base {
     archivesName = "${mod_id}-forge-${minecraft_version}"
 }

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -3,8 +3,6 @@ plugins {
     id 'net.neoforged.moddev'
 }
 
-version = gitVersion()
-
 neoForge {
     version = neoforge_version
     // Automatically enable neoforge AccessTransformers if the file exists


### PR DESCRIPTION
So. This was fun, and turned out to be variable scoping like I expected.

`version` is a project property set in each project. It was correctly set in every project. HOWEVER: I'm inferring from the behaviors of the forge prepareResources task that the forge plugin acts as its own subproject of the forge project, and so was passing a default version value.

allProjects runs for all projects, including sneaky little hidy projects we don't otherwise have direct access to, so this is the cleanest way to make sure the version property is everywhere.

I expect there's a way to bludgeon forge's little plugin into liking us, but I feel like this might be a more universal solution.