### PR TITLE
Add mac build dependency

### DIFF
--- a/buildSrc/src/main/groovy/multiloader-common.gradle
+++ b/buildSrc/src/main/groovy/multiloader-common.gradle
@@ -14,6 +14,15 @@ java {
 }
 
 repositories {
+    // https://github.com/jaredlll08/MultiLoader-Template/issues/75
+    repositories{
+        maven {
+            url = "https://libraries.minecraft.net"
+            content {
+                includeModule("org.lwjgl", "lwjgl-freetype")
+            }
+        }
+    }
     mavenCentral()
     // https://docs.gradle.org/current/userguide/declaring_repositories.html#declaring_content_exclusively_found_in_one_repository
     exclusiveContent {


### PR DESCRIPTION
This LWJGL dependency is required to successfully build on mac. Shouldn't otherwise cause issues.

Topic: lwjgl-mac-dep
Relative: