### PR TITLE
Incorrect error reporting for lousy base items

### DIFF
--- a/common/src/main/java/com/verdantartifice/primalmagick/common/affinities/ItemAffinity.java
+++ b/common/src/main/java/com/verdantartifice/primalmagick/common/affinities/ItemAffinity.java
@@ -93,9 +93,10 @@ public class ItemAffinity extends AbstractAffinity {
             } else if (json.has("set")) {
                 entry.setValues = JsonUtils.toSourceList(json.get("set").getAsJsonObject());
             } else if (json.has("base")) {
-                entry.baseEntryId = ResourceLocation.parse(json.getAsJsonPrimitive("base").getAsString());
+                String base = json.getAsJsonPrimitive("base").getAsString();
+                entry.baseEntryId = ResourceLocation.parse(base);
                 if (!Services.ITEMS_REGISTRY.containsKey(entry.baseEntryId)) {
-                    throw new JsonSyntaxException("Unknown base item " + target + " in affinity JSON for " + affinityId.toString());
+                    throw new JsonSyntaxException("Unknown base item " + base + " in affinity JSON for " + affinityId.toString());
                 }
                 if (json.has("add")) {
                     entry.addValues = JsonUtils.toSourceList(json.get("add").getAsJsonObject());


### PR DESCRIPTION
Apparently I'm busily inventing fake items and getting justifiable errors. Unfortunately the error in the logs doesn't report the unknown item, just the target twice.