### PR TITLE
Improve error handling when self is the same as the base item

### DIFF
--- a/common/src/main/java/com/verdantartifice/primalmagick/common/affinities/ItemAffinity.java
+++ b/common/src/main/java/com/verdantartifice/primalmagick/common/affinities/ItemAffinity.java
@@ -95,6 +95,9 @@ public class ItemAffinity extends AbstractAffinity {
             } else if (json.has("base")) {
                 String base = json.getAsJsonPrimitive("base").getAsString();
                 entry.baseEntryId = ResourceLocation.parse(base);
+                if (entry.baseEntryId.equals(targetId)) {
+                    throw new JsonSyntaxException("Base item cannot be the same as the target at " + affinityId.toString());
+                }
                 if (!Services.ITEMS_REGISTRY.containsKey(entry.baseEntryId)) {
                     throw new JsonSyntaxException("Unknown base item " + base + " in affinity JSON for " + affinityId.toString());
                 }

--- a/common/src/main/java/com/verdantartifice/primalmagick/common/commands/PrimalMagickCommand.java
+++ b/common/src/main/java/com/verdantartifice/primalmagick/common/commands/PrimalMagickCommand.java
@@ -760,29 +760,22 @@ public class PrimalMagickCommand {
 
         Vector<Item> items = new Vector<>();
         Services.ITEMS_REGISTRY.getAll().forEach( (item) -> {
-                ItemStack stack = item.getDefaultInstance();
-
-                ResourceLocation resourceLocation = Services.ITEMS_REGISTRY.getKey(item);
-                if (resourceLocation == null) {
+                ResourceLocation itemId = Services.ITEMS_REGISTRY.getKey(item);
+                if (itemId == null) {
                     // If the Item can't be resolved in registry, it's got problems I can't care about.
                     return;
                 }
-                String namespace = resourceLocation.getNamespace();
+                String namespace = itemId.getNamespace();
                 if (excludeNamespaces != null && excludeNamespaces.contains(namespace)){
                     return;
                 }
 
-                CompletableFuture<SourceList> f = am.getAffinityValuesAsync(stack, level);
-
-                try {
-                    SourceList sources = f.get();
-                    if (sources.isEmpty()){
-                        if (getRecipeCountForItem(recipeManager, registryAccess, item) == 0) {
-                            items.add(item);
+                IAffinity affinityData = am.getOrGenerateItemAffinityAsync(itemId, recipeManager, registryAccess, new ArrayList<>()).join();
+                if (getRecipeCountForItem(recipeManager, registryAccess, item) ==0) {
+                        SourceList sources = affinityData.getTotalAsync(recipeManager, registryAccess, new ArrayList<>()).join();
+                        if (sources.isEmpty()){
+                                items.add(item);
                         }
-                    }
-                } catch (InterruptedException | ExecutionException e) {
-                    e.printStackTrace();
                 }
             }
         );

--- a/common/src/main/java/com/verdantartifice/primalmagick/common/util/DataPackUtils.java
+++ b/common/src/main/java/com/verdantartifice/primalmagick/common/util/DataPackUtils.java
@@ -34,6 +34,7 @@ public class DataPackUtils {
     static String itemFilePrefix = "data/primalmagick/affinities/items/";
     static String entityFilePrefix = "data/primalmagick/affinities/entity_types/";
 
+    static String packName = "primalMagickAffinities";
     static String packMCMetaFilename = "pack.mcmeta";
     static String packMCMeta = """
         {
@@ -51,15 +52,15 @@ public class DataPackUtils {
     static String itemTemplate = """
             { "type": "item", 
               "set": { 
-                "earth": 0, 
-                "sun": 0, 
-                "moon": 0, 
-                "sky": 0, 
-                "sea": 0, 
-                "blood": 0, 
-                "infernal": 0, 
-                "void": 0, 
-                "hallowed": 0 
+                "primalmagick:earth": 0,
+                "primalmagick:sun": 0,
+                "primalmagick:moon": 0,
+                "primalmagick:sky": 0,
+                "primalmagick:sea": 0,
+                "primalmagick:blood": 0,
+                "primalmagick:infernal": 0,
+                "primalmagick:void": 0,
+                "primalmagick:hallowed": 0
               }, 
               "target": "%s"
             }
@@ -68,15 +69,15 @@ public class DataPackUtils {
     static String entityTemplate = """
             { "type": "entity_type", 
               "values": { 
-                "earth": 0, 
-                "sun": 0, 
-                "moon": 0, 
-                "sky": 0, 
-                "sea": 0, 
-                "blood": 0, 
-                "infernal": 0, 
-                "void": 0, 
-                "hallowed": 0 
+                "primalmagick:earth": 0,
+                "primalmagick:sun": 0,
+                "primalmagick:moon": 0,
+                "primalmagick:sky": 0,
+                "primalmagick:sea": 0,
+                "primalmagick:blood": 0,
+                "primalmagick:infernal": 0,
+                "primalmagick:void": 0,
+                "primalmagick:hallowed": 0
               }, 
               "target": "%s"
             }
@@ -87,7 +88,7 @@ public class DataPackUtils {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         ZipOutputStream zos = new ZipOutputStream(bos);
 
-        ZipEntry z = new ZipEntry(packMCMetaFilename);
+        ZipEntry z = new ZipEntry(String.format("%s/%s", packName, packMCMetaFilename));
         zos.putNextEntry(z);
         zos.write(packMCMeta.getBytes());
         zos.closeEntry();
@@ -96,10 +97,12 @@ public class DataPackUtils {
             @Nullable
             ResourceLocation resourceLocation = Services.ITEMS_REGISTRY.getKey(item);
             if (resourceLocation != null) {
+                String namespace= resourceLocation.getNamespace();
+                String path = resourceLocation.getPath();
+                String entryPath = String.format("%s/data/%s/affinities/items/%s.json", packName, namespace, path);
                 String target = resourceLocation.toString();
-                String filename = target.replace(":", "_")+".json";
 
-                z = new ZipEntry(itemFilePrefix + filename);
+                z = new ZipEntry(entryPath);
                 zos.putNextEntry(z);
                 zos.write(String.format(itemTemplate, target).getBytes());
                 zos.closeEntry();
@@ -109,10 +112,12 @@ public class DataPackUtils {
         for (EntityType<?> entityType : sourceEntities) {
             ResourceLocation resourceLocation = Services.ENTITY_TYPES_REGISTRY.getKey(entityType);
             if (resourceLocation != null) {
-                String target = resourceLocation.toString();
-                String filename = target.replace(":", "_") + ".json";
+                String namespace= resourceLocation.getNamespace();
+                String path = resourceLocation.getPath();
                 
-                z = new ZipEntry(entityFilePrefix + filename);
+                String target = resourceLocation.toString();
+                String entryPath = String.format("%s/data/%s/affinities/entity_types/%s.json", packName, namespace, path);
+                z = new ZipEntry(entryPath);
                 zos.putNextEntry(z);
                 zos.write(String.format(entityTemplate, target).getBytes());
                 zos.closeEntry();


### PR DESCRIPTION
So if you search and replace badly you set the base for an item to itself and this renders as a StackOverflowException and a thousand line long stacktrace... and to add insult to injury it doesn't tell you where you made this boneheaded error. 

Let me make your software more idiot-resistant.