### PR TITLE
Improve error handling when self is the same as the base item

### DIFF
--- a/common/src/main/java/com/verdantartifice/primalmagick/common/affinities/ItemAffinity.java
+++ b/common/src/main/java/com/verdantartifice/primalmagick/common/affinities/ItemAffinity.java
@@ -95,6 +95,9 @@ public class ItemAffinity extends AbstractAffinity {
             } else if (json.has("base")) {
                 String base = json.getAsJsonPrimitive("base").getAsString();
                 entry.baseEntryId = ResourceLocation.parse(base);
+                if (entry.baseEntryId.equals(targetId)) {
+                    throw new JsonSyntaxException("Base item cannot be the same as the target at " + affinityId.toString());
+                }
                 if (!Services.ITEMS_REGISTRY.containsKey(entry.baseEntryId)) {
                     throw new JsonSyntaxException("Unknown base item " + base + " in affinity JSON for " + affinityId.toString());
                 }


### PR DESCRIPTION
So if you search and replace badly you set the base for an item to itself and this renders as a StackOverflowException and a thousand line long stacktrace... and to add insult to injury it doesn't tell you where you made this boneheaded error.

Let me make your software more idiot-resistant.

Topic: self-is-base-is-wrong