### PR TITLE
Add waterloggability to some blocks and voxel shapes to two of them.

### DIFF
--- a/common/src/main/java/com/verdantartifice/primalmagick/common/blocks/crafting/ArcaneWorkbenchBlock.java
+++ b/common/src/main/java/com/verdantartifice/primalmagick/common/blocks/crafting/ArcaneWorkbenchBlock.java
@@ -2,6 +2,7 @@ package com.verdantartifice.primalmagick.common.blocks.crafting;
 
 import com.verdantartifice.primalmagick.common.menus.ArcaneWorkbenchMenu;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionResult;
@@ -10,17 +11,24 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ContainerLevelAccess;
+import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.NoteBlockInstrument;
+import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Block definition for the arcane workbench.  An arcane workbench is like a normal workbench, but can
@@ -31,12 +39,19 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 public class ArcaneWorkbenchBlock extends Block {
     public ArcaneWorkbenchBlock() {
         super(Block.Properties.of().mapColor(MapColor.WOOD).ignitedByLava().instrument(NoteBlockInstrument.BASS).strength(1.5F, 6.0F).sound(SoundType.WOOD).noOcclusion());
+
+        registerDefaultState(getStateDefinition().any().setValue(BlockStateProperties.WATERLOGGED, false));
     }
-    
+
+    protected static final VoxelShape SHAPE = Shapes.or(
+            box(2.0, 0.0, 2.0, 14.0, 4.0, 14.0),
+            box(3.0, 4.0, 3.0, 13.0, 10.0, 13.0),
+            box(0.0, 10.0, 0.0, 16.0, 16.0, 16.0)
+            );
+
     @Override
     public VoxelShape getShape(BlockState state, BlockGetter worldIn, BlockPos pos, CollisionContext context) {
-        // TODO Assemble more detailed shape for base table
-        return Shapes.block();
+        return SHAPE;
     }
     
     @Override
@@ -56,5 +71,28 @@ public class ArcaneWorkbenchBlock extends Block {
             });
         }
         return InteractionResult.SUCCESS;
+    }
+
+    @Override
+    protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> pBuilder) {
+        pBuilder.add(BlockStateProperties.WATERLOGGED);
+    }
+
+    @Override
+    public @Nullable BlockState getStateForPlacement(BlockPlaceContext pContext) {
+        return defaultBlockState().setValue(BlockStateProperties.WATERLOGGED, pContext.getLevel().getFluidState(pContext.getClickedPos()).is(Fluids.WATER));
+    }
+
+    @Override
+    protected FluidState getFluidState(BlockState pState) {
+        return pState.getValue(BlockStateProperties.WATERLOGGED) ? Fluids.WATER.getSource(false) : super.getFluidState(pState);
+    }
+
+    @Override
+    protected BlockState updateShape(BlockState pState, Direction pDirection, BlockState pNeighborState, LevelAccessor pLevel, BlockPos pPos, BlockPos pNeighborPos) {
+        if(pState.getValue(BlockStateProperties.WATERLOGGED)){
+            pLevel.scheduleTick(pPos, Fluids.WATER, Fluids.WATER.getTickDelay(pLevel));
+        }
+        return super.updateShape(pState, pDirection, pNeighborState, pLevel, pPos, pNeighborPos);
     }
 }

--- a/common/src/main/java/com/verdantartifice/primalmagick/common/blocks/crafting/RunescribingAltarBlock.java
+++ b/common/src/main/java/com/verdantartifice/primalmagick/common/blocks/crafting/RunescribingAltarBlock.java
@@ -9,19 +9,27 @@ import com.verdantartifice.primalmagick.common.util.ResourceUtils;
 import com.verdantartifice.primalmagick.common.util.VoxelShapeUtils;
 import com.verdantartifice.primalmagick.platform.Services;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.BaseEntityBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Block definition for the runescribing altar.  May be used to apply combinations of runes to
@@ -42,6 +50,8 @@ public class RunescribingAltarBlock extends BaseEntityBlock implements ITieredDe
     public RunescribingAltarBlock(DeviceTier tier, Block.Properties properties) {
         super(properties);
         this.tier = tier;
+
+        registerDefaultState(getStateDefinition().any().setValue(BlockStateProperties.WATERLOGGED, false));
     }
     
     @Override
@@ -74,6 +84,29 @@ public class RunescribingAltarBlock extends BaseEntityBlock implements ITieredDe
             }
         }
         return InteractionResult.SUCCESS;
+    }
+
+    @Override
+    protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> pBuilder) {
+        pBuilder.add(BlockStateProperties.WATERLOGGED);
+    }
+
+    @Override
+    public @Nullable BlockState getStateForPlacement(BlockPlaceContext pContext) {
+        return defaultBlockState().setValue(BlockStateProperties.WATERLOGGED, pContext.getLevel().getFluidState(pContext.getClickedPos()).is(Fluids.WATER));
+    }
+
+    @Override
+    protected FluidState getFluidState(BlockState pState) {
+        return pState.getValue(BlockStateProperties.WATERLOGGED) ? Fluids.WATER.getSource(false) : super.getFluidState(pState);
+    }
+
+    @Override
+    protected BlockState updateShape(BlockState pState, Direction pDirection, BlockState pNeighborState, LevelAccessor pLevel, BlockPos pPos, BlockPos pNeighborPos) {
+        if(pState.getValue(BlockStateProperties.WATERLOGGED)){
+            pLevel.scheduleTick(pPos, Fluids.WATER, Fluids.WATER.getTickDelay(pLevel));
+        }
+        return super.updateShape(pState, pDirection, pNeighborState, pLevel, pPos, pNeighborPos);
     }
 
     @Override

--- a/neoforge/src/generated/resources/assets/primalmagick/blockstates/runecarving_table.json
+++ b/neoforge/src/generated/resources/assets/primalmagick/blockstates/runecarving_table.json
@@ -1,17 +1,32 @@
 {
   "variants": {
-    "facing=east": {
+    "facing=east,waterlogged=false": {
       "model": "primalmagick:block/runecarving_table",
       "y": 90
     },
-    "facing=north": {
+    "facing=east,waterlogged=true": {
+      "model": "primalmagick:block/runecarving_table",
+      "y": 90
+    },
+    "facing=north,waterlogged=false": {
       "model": "primalmagick:block/runecarving_table"
     },
-    "facing=south": {
+    "facing=north,waterlogged=true": {
+      "model": "primalmagick:block/runecarving_table"
+    },
+    "facing=south,waterlogged=false": {
       "model": "primalmagick:block/runecarving_table",
       "y": 180
     },
-    "facing=west": {
+    "facing=south,waterlogged=true": {
+      "model": "primalmagick:block/runecarving_table",
+      "y": 180
+    },
+    "facing=west,waterlogged=false": {
+      "model": "primalmagick:block/runecarving_table",
+      "y": 270
+    },
+    "facing=west,waterlogged=true": {
       "model": "primalmagick:block/runecarving_table",
       "y": 270
     }

--- a/neoforge/src/generated/resources/assets/primalmagick/blockstates/runic_grindstone.json
+++ b/neoforge/src/generated/resources/assets/primalmagick/blockstates/runic_grindstone.json
@@ -1,54 +1,107 @@
 {
   "variants": {
-    "face=ceiling,facing=east": {
+    "face=ceiling,facing=east,waterlogged=false": {
       "model": "primalmagick:block/runic_grindstone",
       "x": 180,
       "y": 270
     },
-    "face=ceiling,facing=north": {
+    "face=ceiling,facing=east,waterlogged=true": {
+      "model": "primalmagick:block/runic_grindstone",
+      "x": 180,
+      "y": 270
+    },
+    "face=ceiling,facing=north,waterlogged=false": {
       "model": "primalmagick:block/runic_grindstone",
       "x": 180,
       "y": 180
     },
-    "face=ceiling,facing=south": {
+    "face=ceiling,facing=north,waterlogged=true": {
+      "model": "primalmagick:block/runic_grindstone",
+      "x": 180,
+      "y": 180
+    },
+    "face=ceiling,facing=south,waterlogged=false": {
       "model": "primalmagick:block/runic_grindstone",
       "x": 180
     },
-    "face=ceiling,facing=west": {
+    "face=ceiling,facing=south,waterlogged=true": {
+      "model": "primalmagick:block/runic_grindstone",
+      "x": 180
+    },
+    "face=ceiling,facing=west,waterlogged=false": {
       "model": "primalmagick:block/runic_grindstone",
       "x": 180,
       "y": 90
     },
-    "face=floor,facing=east": {
+    "face=ceiling,facing=west,waterlogged=true": {
+      "model": "primalmagick:block/runic_grindstone",
+      "x": 180,
+      "y": 90
+    },
+    "face=floor,facing=east,waterlogged=false": {
       "model": "primalmagick:block/runic_grindstone",
       "y": 90
     },
-    "face=floor,facing=north": {
+    "face=floor,facing=east,waterlogged=true": {
+      "model": "primalmagick:block/runic_grindstone",
+      "y": 90
+    },
+    "face=floor,facing=north,waterlogged=false": {
       "model": "primalmagick:block/runic_grindstone"
     },
-    "face=floor,facing=south": {
+    "face=floor,facing=north,waterlogged=true": {
+      "model": "primalmagick:block/runic_grindstone"
+    },
+    "face=floor,facing=south,waterlogged=false": {
       "model": "primalmagick:block/runic_grindstone",
       "y": 180
     },
-    "face=floor,facing=west": {
+    "face=floor,facing=south,waterlogged=true": {
+      "model": "primalmagick:block/runic_grindstone",
+      "y": 180
+    },
+    "face=floor,facing=west,waterlogged=false": {
       "model": "primalmagick:block/runic_grindstone",
       "y": 270
     },
-    "face=wall,facing=east": {
+    "face=floor,facing=west,waterlogged=true": {
+      "model": "primalmagick:block/runic_grindstone",
+      "y": 270
+    },
+    "face=wall,facing=east,waterlogged=false": {
       "model": "primalmagick:block/runic_grindstone",
       "x": 90,
       "y": 90
     },
-    "face=wall,facing=north": {
+    "face=wall,facing=east,waterlogged=true": {
+      "model": "primalmagick:block/runic_grindstone",
+      "x": 90,
+      "y": 90
+    },
+    "face=wall,facing=north,waterlogged=false": {
       "model": "primalmagick:block/runic_grindstone",
       "x": 90
     },
-    "face=wall,facing=south": {
+    "face=wall,facing=north,waterlogged=true": {
+      "model": "primalmagick:block/runic_grindstone",
+      "x": 90
+    },
+    "face=wall,facing=south,waterlogged=false": {
       "model": "primalmagick:block/runic_grindstone",
       "x": 90,
       "y": 180
     },
-    "face=wall,facing=west": {
+    "face=wall,facing=south,waterlogged=true": {
+      "model": "primalmagick:block/runic_grindstone",
+      "x": 90,
+      "y": 180
+    },
+    "face=wall,facing=west,waterlogged=false": {
+      "model": "primalmagick:block/runic_grindstone",
+      "x": 90,
+      "y": 270
+    },
+    "face=wall,facing=west,waterlogged=true": {
       "model": "primalmagick:block/runic_grindstone",
       "x": 90,
       "y": 270

--- a/neoforge/src/generated/resources/assets/primalmagick/blockstates/spellcrafting_altar.json
+++ b/neoforge/src/generated/resources/assets/primalmagick/blockstates/spellcrafting_altar.json
@@ -1,17 +1,32 @@
 {
   "variants": {
-    "facing=east": {
+    "facing=east,waterlogged=false": {
       "model": "primalmagick:block/spellcrafting_altar",
       "y": 90
     },
-    "facing=north": {
+    "facing=east,waterlogged=true": {
+      "model": "primalmagick:block/spellcrafting_altar",
+      "y": 90
+    },
+    "facing=north,waterlogged=false": {
       "model": "primalmagick:block/spellcrafting_altar"
     },
-    "facing=south": {
+    "facing=north,waterlogged=true": {
+      "model": "primalmagick:block/spellcrafting_altar"
+    },
+    "facing=south,waterlogged=false": {
       "model": "primalmagick:block/spellcrafting_altar",
       "y": 180
     },
-    "facing=west": {
+    "facing=south,waterlogged=true": {
+      "model": "primalmagick:block/spellcrafting_altar",
+      "y": 180
+    },
+    "facing=west,waterlogged=false": {
+      "model": "primalmagick:block/spellcrafting_altar",
+      "y": 270
+    },
+    "facing=west,waterlogged=true": {
       "model": "primalmagick:block/spellcrafting_altar",
       "y": 270
     }

--- a/neoforge/src/generated/resources/assets/primalmagick/blockstates/wand_assembly_table.json
+++ b/neoforge/src/generated/resources/assets/primalmagick/blockstates/wand_assembly_table.json
@@ -1,17 +1,32 @@
 {
   "variants": {
-    "facing=east": {
+    "facing=east,waterlogged=false": {
       "model": "primalmagick:block/wand_assembly_table",
       "y": 90
     },
-    "facing=north": {
+    "facing=east,waterlogged=true": {
+      "model": "primalmagick:block/wand_assembly_table",
+      "y": 90
+    },
+    "facing=north,waterlogged=false": {
       "model": "primalmagick:block/wand_assembly_table"
     },
-    "facing=south": {
+    "facing=north,waterlogged=true": {
+      "model": "primalmagick:block/wand_assembly_table"
+    },
+    "facing=south,waterlogged=false": {
       "model": "primalmagick:block/wand_assembly_table",
       "y": 180
     },
-    "facing=west": {
+    "facing=south,waterlogged=true": {
+      "model": "primalmagick:block/wand_assembly_table",
+      "y": 180
+    },
+    "facing=west,waterlogged=false": {
+      "model": "primalmagick:block/wand_assembly_table",
+      "y": 270
+    },
+    "facing=west,waterlogged=true": {
       "model": "primalmagick:block/wand_assembly_table",
       "y": 270
     }


### PR DESCRIPTION
Makes several blocks waterloggable and adds voxel shapes for the Arcane Workbench and Runescribing Table. I may add more of both to this PR and/or a new one at a later date.

The main purpose of this is to improve the mod's aesthetics when used with Dragon Survival (playing as a Sea Dragon encourages underwater bases).