### PR TITLE
Fix NPE in onUseHoe when tool-use event has no player

### DIFF
--- a/common/src/main/java/com/verdantartifice/primalmagick/common/events/PlayerEvents.java
+++ b/common/src/main/java/com/verdantartifice/primalmagick/common/events/PlayerEvents.java
@@ -583,6 +583,9 @@ public class PlayerEvents {
     }
     
     public static void onUseHoe(Player player, UseOnContext context, Consumer<BlockState> stateUpdater) {
+        if (context.getPlayer() == null) {
+            return;  // Tool-use events without a player have nothing to do here
+        }
         ItemStack stack = context.getItemInHand();
         int enchantLevel = EnchantmentHelperPM.getEnchantmentLevel(stack, EnchantmentsPM.VERDANT, context.getPlayer().registryAccess());
         if (enchantLevel > 0) {


### PR DESCRIPTION
I'm on primalmagick-neoforge-1.21.1-6.0.7  + smarterfarmers-1.21-2.2.4-neoforge on neoforge 21.1.249 in 1.21.1
When a smarterfarmer does tilling it uses a Hoe, without setting simulated, so PrimalMagick crashes.

As its easier to show code:
a simple guard fixed it for me. Since i don't know your codebase that well i didn't touch much, but is the player from context different from the player in the parameter?

Anyway, thank you for the cool mod, feel free to solve this differently